### PR TITLE
fix(importer): case-insensitive SO/DO stat lookup (Tohit_Buff)

### DIFF
--- a/src/utils/game-importer/importer.test.ts
+++ b/src/utils/game-importer/importer.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { loadDataset } from '@/data/dataset';
+import { importFromParsedData } from './importer';
+import type { GameExportData, GameExportEnhancement } from './types';
+
+/** Build a minimal valid export with a single Inherent power holding `enh`. */
+function exportWithEnhancement(enh: GameExportEnhancement): GameExportData {
+  return {
+    header: {
+      characterName: 'Test',
+      level: 50,
+      origin: 'Technology',
+      archetype: 'Class_Corruptor',
+    },
+    powers: [
+      {
+        level: 1,
+        category: 'Inherent',
+        powerset: 'Inherent',
+        powerName: 'Health',
+        enhancements: [enh],
+      },
+    ],
+  };
+}
+
+function so(uid: string): GameExportEnhancement {
+  return { uid, level: 50, boost: undefined, attuned: false };
+}
+
+describe('importer SO/DO stat resolution', () => {
+  beforeAll(async () => {
+    await loadDataset('homecoming');
+  });
+
+  it('resolves a ToHit Buff SO whose stat is title-cased differently by the exporter', () => {
+    // Regression: exporter emits "Tohit_Buff" (lowercase h) but GENERIC_STAT_MAP
+    // keys it as "ToHit_Buff". The SO/DO path used to do an exact-only lookup and
+    // dropped it with "Unknown SO/DO stat: Tohit_Buff".
+    const result = importFromParsedData(exportWithEnhancement(so('Technology_Tohit_Buff')));
+
+    expect(result.warnings.filter((w) => w.type === 'enhancement')).toEqual([]);
+    expect(result.summary.enhancementsImported).toBe(1);
+    expect(result.summary.enhancementsFailed).toBe(0);
+  });
+
+  it('still resolves canonically-cased SO stats', () => {
+    const result = importFromParsedData(exportWithEnhancement(so('Magic_Accuracy')));
+    expect(result.warnings.filter((w) => w.type === 'enhancement')).toEqual([]);
+    expect(result.summary.enhancementsImported).toBe(1);
+  });
+
+  it('still warns on a genuinely unknown SO stat', () => {
+    const result = importFromParsedData(exportWithEnhancement(so('Technology_Nonsense')));
+    expect(result.warnings.some((w) => w.message.includes('Unknown SO/DO stat'))).toBe(true);
+  });
+});

--- a/src/utils/game-importer/importer.ts
+++ b/src/utils/game-importer/importer.ts
@@ -220,6 +220,24 @@ const SO_STAT_MAP: Record<string, string> = {
   'Run': 'Run Speed',
 };
 
+/**
+ * Resolve a stat key against one or more maps: exact match across all maps
+ * first, then a case-insensitive fallback. External tools titleCase stat
+ * names inconsistently ("Tohit_Buff" vs "ToHit_Buff", "EndMod" vs "Endmod"),
+ * so an exact-only lookup silently drops otherwise-valid enhancements.
+ */
+function lookupStat(key: string, ...maps: Record<string, string>[]): string | undefined {
+  for (const map of maps) {
+    if (map[key] !== undefined) return map[key];
+  }
+  const lower = key.toLowerCase();
+  for (const map of maps) {
+    const hit = Object.entries(map).find(([k]) => k.toLowerCase() === lower);
+    if (hit) return hit[1];
+  }
+  return undefined;
+}
+
 interface ParsedSO {
   /** The stat suffix after origin prefixes are stripped (e.g. "Accuracy", "Run"). */
   stat: string;
@@ -873,8 +891,7 @@ function resolveEnhancement(enh: GameExportEnhancement): EnhancementResolveResul
   if (genericPrefix && !hasIOSetPieceSuffix(uid)) {
     const statPart = uid.slice(genericPrefix.length);
     // Case-insensitive lookup (external tool titleCase may differ: "Tohit_Buff" vs "ToHit_Buff")
-    const stat = GENERIC_STAT_MAP[statPart]
-      ?? Object.entries(GENERIC_STAT_MAP).find(([k]) => k.toLowerCase() === statPart.toLowerCase())?.[1];
+    const stat = lookupStat(statPart, GENERIC_STAT_MAP);
     if (stat) {
       const enhancement = createGenericIOEnhancement(
         stat as any,
@@ -896,7 +913,7 @@ function resolveEnhancement(enh: GameExportEnhancement): EnhancementResolveResul
   // SOs/DOs have an origin prefix but no _[A-F] piece suffix.
   const soResult = parseSOEnhancement(uid);
   if (soResult !== null) {
-    const stat = SO_STAT_MAP[soResult.stat] ?? GENERIC_STAT_MAP[soResult.stat];
+    const stat = lookupStat(soResult.stat, SO_STAT_MAP, GENERIC_STAT_MAP);
     if (stat) {
       const enhancement = createOriginEnhancement(
         stat as any,


### PR DESCRIPTION
## Problem
The direct game importer logged:
```
[enhancement]Unknown SO/DO stat: Tohit_Buff: Technology_Tohit_Buff
```
SO/DO enhancements with a To Hit Buff (e.g. `Technology_Tohit_Buff`) were silently dropped on import.

## Root cause
`GENERIC_STAT_MAP` keys the stat as `ToHit_Buff` (capital H), but the exporter emits `Tohit_Buff` (lowercase h). The **generic-IO** path already had a case-insensitive fallback for exactly this ("external tool titleCase may differ"), but the **SO/DO** path did an exact-only lookup — so any SO/DO stat whose canonical key has non-trivial casing failed.

## Fix
Extracted a shared `lookupStat()` helper — exact match across all provided maps first, then a case-insensitive fallback — and used it on both the generic-IO and SO/DO paths. This fixes `Tohit_Buff` and hardens every other casing-sensitive SO stat in one place.

## Tests
New `src/utils/game-importer/importer.test.ts`:
- ✅ resolves `Technology_Tohit_Buff` with **no** enhancement warning (the regression)
- ✅ still resolves canonically-cased SOs (`Magic_Accuracy`)
- ✅ still warns on a genuinely unknown stat (`Technology_Nonsense`)

Full suite **101/101**, `tsc --noEmit` clean.

> Independent of the Heal/Absorb work in #12 — branched off `main`, touches only the importer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)